### PR TITLE
Pull font from CurFontStyle to be compatible with mods that might set…

### DIFF
--- a/Source/Interface/Theme.cs
+++ b/Source/Interface/Theme.cs
@@ -5,8 +5,6 @@ namespace Bubbles.Interface
 {
     internal static class Theme
     {
-        private static readonly GUIStyle BaseFontStyle = new GUIStyle(Text.fontStyles[(int) GameFont.Medium]) { alignment = TextAnchor.MiddleCenter, clipping = TextClipping.Clip, padding = new RectOffset(0, 0, 0, 0) };
-
         public static bool Activated { get; set; } = true;
         public static bool DoAnimals { get; set; } = true;
         public static bool DoNonPlayer { get; set; } = true;
@@ -39,7 +37,13 @@ namespace Bubbles.Interface
         public static Color CombatSelectedForeColor { get; set; } = Color.black;
         public static Color CombatSelectedBackColor { get; set; } = new Color(1f, 0.5f, 0.5f);
 
-        public static GUIStyle GetFont(float scale) => new GUIStyle(BaseFontStyle) { fontSize = Mathf.CeilToInt(FontSize * scale) };
+        public static GUIStyle GetFont(float scale) => new GUIStyle(Text.CurFontStyle)
+        {
+            alignment = TextAnchor.MiddleCenter,
+            clipping = TextClipping.Clip,
+            padding = new RectOffset(0, 0, 0, 0),
+            fontSize = Mathf.CeilToInt(FontSize * scale)
+        };
 
         public static Rot4 GetOffsetDirection() => new Rot4(OffsetDirection);
     }


### PR DESCRIPTION
… custom fonts.

Quick fix for being compatible with both vanilla and RimTheme custom font. Since font size is customizable via RimHUD this should provide sufficient.

No RimTheme (RimHUD font size set to 13)
![bild](https://user-images.githubusercontent.com/1334297/78833493-43cdeb00-79ed-11ea-9ba1-04bc30755f35.png)

With RimTheme custom font
![bild](https://user-images.githubusercontent.com/1334297/78833659-87c0f000-79ed-11ea-98db-aaa7fd624eed.png)

Note I use a larger font size in my theme (12, 14, 16 from tiny, small and medium) hence why the last picture is slightly larger. (RimHUD still set to 13)

But is still compatible with RimHUD integration, here is use a 9 sized scaling.
![bild](https://user-images.githubusercontent.com/1334297/78833835-d1a9d600-79ed-11ea-8bb6-e95f114c4db1.png)

This was all tested on the newly (at the time of writing this) released 1.1.2597 patch.

